### PR TITLE
feat: Changes for ajustments at Call Type

### DIFF
--- a/app/Http/Controllers/CallController.php
+++ b/app/Http/Controllers/CallController.php
@@ -47,6 +47,7 @@ class CallController extends Controller
             'complement' => 'nullable|string',
             'observation' => 'nullable|string',
             'output_id' => 'nullable|exists:outputs,id',
+            'memorandum_1doc' => 'nullable|string|max:15',
         ]);
 
         $call = Call::create($validated);

--- a/app/Models/Call.php
+++ b/app/Models/Call.php
@@ -22,6 +22,7 @@ class Call extends Model
         'status',
         'observation',
         'output_id',
+        'memorandum_1doc',
     ];
 
     // Tipos de chamado

--- a/database/migrations/2025_08_02_041050_create_calls_table.php
+++ b/database/migrations/2025_08_02_041050_create_calls_table.php
@@ -13,11 +13,12 @@ return new class extends Migration
     {
         Schema::create('calls', function (Blueprint $table) {
             $table->id();
-            $table->enum('type', ['whatssap', 'conectar_cabedelo', 'personally', 'phone', 'other'])->default('phone');
+            $table->enum('type', ['call_center', 'conectar_cabedelo', 'directive_solicitation', '1doc', 'other'])->default('call_center');
             $table->string('service_order', '30')->nullable();
             $table->string('connect_code', '20')->nullable();
-            $table->string('phone')->nullable();
+            $table->string('phone', '15')->nullable();
             $table->string('applicant')->nullable();
+            $table->string('memorandum_1doc', '15')->nullable();
             $table->text('destination');
             $table->string('cep', 8)->nullable();
             $table->string('complement')->nullable();

--- a/resources/views/calls/create.blade.php
+++ b/resources/views/calls/create.blade.php
@@ -24,11 +24,11 @@
                             <select id="type" name="type" required class="mt-1 block w-full py-2 px-3 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm @error('type') border-red-300 text-red-900 @enderror">
                                 class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm @error('type') border-red-300 text-red-900 @enderror">
                                 <option value="">Selecione o tipo</option>
-                                <option value="whatssap" @if(old('type')=='WhatsApp') selected @endif>WhatsApp</option>
-                                <option value="phone" @if(old('type')=='Telefone') selected @endif>Telefone</option>
+                                <option value="1doc" @if(old('type')=='Solicitanção 1Doc') selected @endif>Solicitanção 1Doc</option>
+                                <option value="call_center" @if(old('type')=='Call Center') selected @endif>Call Center</option>
                                 <option value="conectar_cabedelo" @if(old('type')=='Conecta_App') selected @endif>Conecta App</option>
-                                <option value="personally" @if(old('type')=='Pessoalmente') selected @endif>Pessoalmente</option>
-                                <option value="other" @if(old('type')=='Outro') selected @endif>Outro</option>
+                                <option value="directive_solicitation" @if(old('type')=='Solicitação Diretiva') selected @endif>Solicitação Diretiva</option>
+                                <option value="other" @if(old('type')=='Outros') selected @endif>Outros</option>
                             </select>
                             @error('type')
                                 <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
@@ -58,6 +58,19 @@
                                 placeholder="Código do cliente">
                             @error('connect_code')
                                 <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                            @enderror
+                        </div>
+
+                        <!-- Memorando 1Doc -->
+                        <div>
+                            <label for="memorandum_1doc" class="block text-sm font-medium text-gray-700">
+                                Memorando 1Doc
+                            </label>
+                            <input type="text" id="memorandum_1doc" name="memorandum_1doc" value="{{ old('memorandum_1doc') }}"
+                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm @error('memorandum_1doc') border-red-300 text-red-900 @enderror"
+                                   placeholder="Número do Memorando">
+                            @error('memorandum_1doc')
+                            <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
                             @enderror
                         </div>
 

--- a/resources/views/calls/show.blade.php
+++ b/resources/views/calls/show.blade.php
@@ -43,10 +43,19 @@
                             <p class="text-sm font-medium text-gray-500">Tipo</p>
                             <p class="mt-1 text-sm text-gray-900 capitalize">{{ str_replace('_', ' ', $call->type) }}</p>
                         </div>
+                        @if($call->connect_code)
                         <div>
                             <p class="text-sm font-medium text-gray-500">Código App Conecta</p>
                             <p class="mt-1 text-sm text-gray-900">{{ $call->connect_code ?? 'N/A' }}</p>
                         </div>
+                        @endif
+{{--                        {{dd($call->memorandum_1doc)}}--}}
+{{--                        @if($call->me)--}}
+{{--                            <div>--}}
+{{--                                <p class="text-sm font-medium text-gray-500">Código App Conecta</p>--}}
+{{--                                <p class="mt-1 text-sm text-gray-900">{{ $call->connect_code ?? 'N/A' }}</p>--}}
+{{--                            </div>--}}
+{{--                        @endif--}}
                         <div>
                             <p class="text-sm font-medium text-gray-500">Telefone</p>
                             <p class="mt-1 text-sm text-gray-900">{{ $call->phone ?? 'N/A' }}</p>
@@ -62,12 +71,12 @@
                                     @php
                                         $statusClasses = [
                                             'in_progress' => 'bg-yellow-100 text-yellow-800',
-                                            'completed' => 'bg-green-100 text-green-800',
+                                            'finished' => 'bg-green-100 text-green-800',
                                             'cancelled  ' => 'bg-red-100 text-red-800'
                                         ];
                                         $statusNameCall = [
                                             'in_progress' => 'Em andamento',
-                                            'completed' => 'Completo',
+                                            'finished' => 'Finalizado',
                                             'cancelled  ' => 'Cancelado'
                                         ];
                                         $statusClass = $statusClasses[$call->status] ?? 'bg-gray-100 text-gray-800';

--- a/resources/views/calls/show.blade.php
+++ b/resources/views/calls/show.blade.php
@@ -49,13 +49,12 @@
                             <p class="mt-1 text-sm text-gray-900">{{ $call->connect_code ?? 'N/A' }}</p>
                         </div>
                         @endif
-{{--                        {{dd($call->memorandum_1doc)}}--}}
-{{--                        @if($call->me)--}}
-{{--                            <div>--}}
-{{--                                <p class="text-sm font-medium text-gray-500">Código App Conecta</p>--}}
-{{--                                <p class="mt-1 text-sm text-gray-900">{{ $call->connect_code ?? 'N/A' }}</p>--}}
-{{--                            </div>--}}
-{{--                        @endif--}}
+                        @if($call->memorandum_1doc)
+                            <div>
+                                <p class="text-sm font-medium text-gray-500">Memorando 1Doc</p>
+                                <p class="mt-1 text-sm text-gray-900">{{ $call->memorandum_1doc ?? 'N/A' }}</p>
+                            </div>
+                        @endif
                         <div>
                             <p class="text-sm font-medium text-gray-500">Telefone</p>
                             <p class="mt-1 text-sm text-gray-900">{{ $call->phone ?? 'N/A' }}</p>


### PR DESCRIPTION
# Alterações aplicadas
Conforme solicitado, fiz a mesma troca no formulário [resources/views/entries/create.blade.php](cci:7://file:///C:/Projetos/Php/sistema-de-estoque/resources/views/entries/create.blade.php:0:0-0:0):

- Substituí o `<select>` de produto por um `<input list="products_datalist">` com um `<input type="hidden">` para `products[][product_id]`.
- Criei/compartilhei um `<datalist id="products_datalist">` populado a partir de `@json($products)`.
- Adicionei mapeamento nome → ID, prevenção de duplicidade entre linhas e validação no submit (exige produto válido da lista e sem duplicados).

# Detalhes principais
- Em [resources/views/entries/create.blade.php](cci:7://file:///C:/Projetos/Php/sistema-de-estoque/resources/views/entries/create.blade.php:0:0-0:0):
  - Usei `products[IDX][product_label]` (visível) + `products[IDX][product_id]` (hidden).
  - Validação dispara em `change/blur` e no submit.
  - O `datalist` é único por `id` e só é criado se ainda não existir, evitando duplicação entre telas.

# Status
A tela de cadastro de entrada agora usa datalist para produtos, mantendo o backend recebendo `product_id`. Se quiser, posso aplicar esse padrão em outras telas também.